### PR TITLE
fix: update node version in workflow script

### DIFF
--- a/.github/workflows/sync-datasets.yml
+++ b/.github/workflows/sync-datasets.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
PR to Fix GitHub Actions Workflow Issue in Datasets Repo

Hi!

I’ve been getting notifications that the GitHub Actions workflow in the datasets repo has been failing. The issue was caused by the use of the `||=` operator in one of the dependencies, which isn’t supported in the currently specified Node.js version (v14).

To fix this, I’ve created a pull request that updates the workflow to use Node.js v18, which fully supports the syntax and works with the rest of the packages being used.

Let me know if you need me to tweak anything in the PR. Thanks!

Best,
Ritin

